### PR TITLE
Using BaseActivityEventListener instead of ActivityEventListener

### DIFF
--- a/src/main/java/com/surialabs/rn/braintree/Braintree.java
+++ b/src/main/java/com/surialabs/rn/braintree/Braintree.java
@@ -1,38 +1,35 @@
 package com.surialabs.rn.braintree;
 
-import android.content.Intent;
-import android.content.Context;
 import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
 
-import com.braintreepayments.api.PaymentRequest;
-import com.braintreepayments.api.models.PaymentMethodNonce;
-import com.braintreepayments.api.BraintreePaymentActivity;
 import com.braintreepayments.api.BraintreeFragment;
-import com.braintreepayments.api.exceptions.InvalidArgumentException;
-import com.braintreepayments.api.models.CardBuilder;
+import com.braintreepayments.api.BraintreePaymentActivity;
 import com.braintreepayments.api.Card;
+import com.braintreepayments.api.PaymentRequest;
+import com.braintreepayments.api.exceptions.InvalidArgumentException;
 import com.braintreepayments.api.interfaces.PaymentMethodNonceCreatedListener;
-
+import com.braintreepayments.api.models.CardBuilder;
+import com.braintreepayments.api.models.PaymentMethodNonce;
+import com.facebook.react.bridge.BaseActivityEventListener;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ActivityEventListener;
 
-public class Braintree extends ReactContextBaseJavaModule implements ActivityEventListener {
+public class Braintree extends ReactContextBaseJavaModule {
   private static final int PAYMENT_REQUEST = 1;
   private String token;
 
   private Callback successCallback;
   private Callback errorCallback;
 
-  private Context mActivityContext;
-
   private BraintreeFragment mBraintreeFragment;
 
   public Braintree(ReactApplicationContext reactContext) {
     super(reactContext);
-    reactContext.addActivityEventListener(this);
+    reactContext.addActivityEventListener(new BraintreeActivityListener());
   }
 
   @Override
@@ -96,31 +93,28 @@ public class Braintree extends ReactContextBaseJavaModule implements ActivityEve
     );
   }
 
-  @Override
-  public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
-    if (requestCode == PAYMENT_REQUEST) {
-      switch (resultCode) {
-        case Activity.RESULT_OK:
-          PaymentMethodNonce paymentMethodNonce = data.getParcelableExtra(
-            BraintreePaymentActivity.EXTRA_PAYMENT_METHOD_NONCE
-          );
-          this.successCallback.invoke(paymentMethodNonce.getNonce());
-          break;
-        case BraintreePaymentActivity.BRAINTREE_RESULT_DEVELOPER_ERROR:
-        case BraintreePaymentActivity.BRAINTREE_RESULT_SERVER_ERROR:
-        case BraintreePaymentActivity.BRAINTREE_RESULT_SERVER_UNAVAILABLE:
-          this.errorCallback.invoke(
-            data.getSerializableExtra(BraintreePaymentActivity.EXTRA_ERROR_MESSAGE)
-          );
-          break;
-        default:
-          break;
+  private class BraintreeActivityListener extends BaseActivityEventListener {
+    @Override
+    public void onActivityResult(Activity activity, final int requestCode, final int resultCode, final Intent data) {
+      if (requestCode == PAYMENT_REQUEST) {
+        switch (resultCode) {
+          case Activity.RESULT_OK:
+            PaymentMethodNonce paymentMethodNonce = data.getParcelableExtra(
+                    BraintreePaymentActivity.EXTRA_PAYMENT_METHOD_NONCE
+            );
+            successCallback.invoke(paymentMethodNonce.getNonce());
+            break;
+          case BraintreePaymentActivity.BRAINTREE_RESULT_DEVELOPER_ERROR:
+          case BraintreePaymentActivity.BRAINTREE_RESULT_SERVER_ERROR:
+          case BraintreePaymentActivity.BRAINTREE_RESULT_SERVER_UNAVAILABLE:
+            errorCallback.invoke(
+                    data.getSerializableExtra(BraintreePaymentActivity.EXTRA_ERROR_MESSAGE)
+            );
+            break;
+          default:
+            break;
+        }
       }
     }
-  }
-
-  @Override
-  public void onNewIntent(Intent intent){
-    
   }
 }


### PR DESCRIPTION
This addresses breaking API changes introduced in RN 0.33
See https://github.com/facebook/react-native/commit/fbd2e139103e3d520f6dfc009d6200f8b8168e35#commitcomment-18998993
and http://facebook.github.io/react-native/releases/0.35/docs/native-modules-android.html#getting-activity-result-from-startactivityforresult
